### PR TITLE
add status attribute to post in all relevant api functions

### DIFF
--- a/www/api/posts_all.php
+++ b/www/api/posts_all.php
@@ -4,6 +4,9 @@
 // del.icio.us behavior:
 // - doesn't include the filtered tag as an attribute on the root element (we do)
 
+// Scuttle behavior:
+// - returns privacy status of each bookmark.
+
 // Force HTTP authentication first!
 $httpContentType = 'text/xml';
 require_once 'httpauth.inc.php';
@@ -40,7 +43,7 @@ foreach($bookmarks['bookmarks'] as $row) {
         $taglist = 'system:unfiled';
     }
 
-    echo "\t<post href=\"". filter($row['bAddress'], 'xml') .'" description="'. filter($row['bTitle'], 'xml') .'" '. $description .'hash="'. md5($row['bAddress']) .'" tag="'. filter($taglist, 'xml') .'" time="'. gmdate('Y-m-d\TH:i:s\Z', strtotime($row['bDatetime'])) ."\" />\r\n";
+    echo "\t<post href=\"". filter($row['bAddress'], 'xml') .'" description="'. filter($row['bTitle'], 'xml') .'" '. $description .'hash="'. md5($row['bAddress']) .'" tag="'. filter($taglist, 'xml') .'" time="'. gmdate('Y-m-d\TH:i:s\Z', strtotime($row['bDatetime'])) . '" status="'. filter($row['bStatus'], 'xml') ."\" />\r\n";
 }
 
 echo '</posts>';

--- a/www/api/posts_get.php
+++ b/www/api/posts_get.php
@@ -10,6 +10,7 @@
  *
  * Scuttle behavior:
  * - Uses today, instead of the last bookmarked date, if no date is specified
+ * - returns privacy status of each bookmark.
  *
  * SemanticScuttle - your social bookmark manager.
  *
@@ -75,7 +76,7 @@ foreach ($bookmarks['bookmarks'] as $row) {
         $taglist = 'system:unfiled';
     }
 
-    echo "\t<post href=\"". filter($row['bAddress'], 'xml') .'" description="'. filter($row['bTitle'], 'xml') .'" '. $description .'hash="'. $row['bHash'] .'" others="'. $bookmarkservice->countOthers($row['bAddress']) .'" tag="'. filter($taglist, 'xml') .'" time="'. gmdate('Y-m-d\TH:i:s\Z', strtotime($row['bDatetime'])) ."\" />\r\n";
+    echo "\t<post href=\"". filter($row['bAddress'], 'xml') .'" description="'. filter($row['bTitle'], 'xml') .'" '. $description .'hash="'. $row['bHash'] .'" others="'. $bookmarkservice->countOthers($row['bAddress']) .'" tag="'. filter($taglist, 'xml') .'" time="'. gmdate('Y-m-d\TH:i:s\Z', strtotime($row['bDatetime'])) . '" status="'. filter($row['bStatus'], 'xml') ."\" />\r\n";
 }
 
 echo '</posts>';

--- a/www/api/posts_public.php
+++ b/www/api/posts_public.php
@@ -4,6 +4,9 @@
 // del.icio.us behavior:
 // - doesn't include the filtered tag as an attribute on the root element (we do)
 
+// Scuttle behavior:
+// - returns privacy status of each bookmark.
+
 // Force HTTP authentication first!
 //require_once('httpauth.inc.php');
 $httpContentType = 'text/xml';
@@ -41,7 +44,7 @@ foreach($bookmarks['bookmarks'] as $row) {
         $taglist = 'system:unfiled';
     }
 
-    echo "\t<post href=\"". filter($row['bAddress'], 'xml') .'" description="'. filter($row['bTitle'], 'xml') .'" '. $description .'hash="'. md5($row['bAddress']) .'" tag="'. filter($taglist, 'xml') .'" time="'. gmdate('Y-m-d\TH:i:s\Z', strtotime($row['bDatetime'])) ."\" />\r\n";
+    echo "\t<post href=\"". filter($row['bAddress'], 'xml') .'" description="'. filter($row['bTitle'], 'xml') .'" '. $description .'hash="'. md5($row['bAddress']) .'" tag="'. filter($taglist, 'xml') .'" time="'. gmdate('Y-m-d\TH:i:s\Z', strtotime($row['bDatetime'])) . '" status="'. filter($row['bStatus'], 'xml') ."\" />\r\n";
 }
 
 echo '</posts>';

--- a/www/api/posts_recent.php
+++ b/www/api/posts_recent.php
@@ -4,6 +4,9 @@
  * optionally filtered by tag and/or number of posts
  * (default 15, max 100, just like del.icio.us).
  *
+ * Scuttle behavior:
+ * - returns privacy status of each bookmark.
+ *
  * SemanticScuttle - your social bookmark manager.
  *
  * PHP version 5.
@@ -75,7 +78,7 @@ foreach ($bookmarks['bookmarks'] as $row) {
         $taglist = 'system:unfiled';
     }
 
-    echo "\t<post href=\"". filter($row['bAddress'], 'xml') .'" description="'. filter($row['bTitle'], 'xml') .'" '. $description .'hash="'. $row['bHash'] .'" tag="'. filter($taglist, 'xml') .'" time="'. gmdate('Y-m-d\TH:i:s\Z', strtotime($row['bDatetime'])) ."\" />\r\n";
+    echo "\t<post href=\"". filter($row['bAddress'], 'xml') .'" description="'. filter($row['bTitle'], 'xml') .'" '. $description .'hash="'. $row['bHash'] .'" tag="'. filter($taglist, 'xml') .'" time="'. gmdate('Y-m-d\TH:i:s\Z', strtotime($row['bDatetime'])) . '" status="'. filter($row['bStatus'], 'xml') ."\" />\r\n";
 }
 
 echo '</posts>';


### PR DESCRIPTION
Hi,

Android Apps (and other 3rd-party applications) for semantic Scuttle, like [scuttloid](https://github.com/ilesinge/scuttloid) can't access the privacy status of the bookmarks. It is needed to highlight private posts and to keep the previous privacy status when editing a bookmark.

I have added a status attribute where necessary.

The changes should not brake existing clients (tested with scuttloid), because it's just an additional attribute, that will be ignored, if not implemented. For the same reason it will stay compatible with the delicious API.

While looking at the API, I found that posts_public.php is confusing because it also returns private bookmarks of the current user. So I let it have the status attribute, too.

Thanks
David
